### PR TITLE
setting up VS Code for a full IDE experience with pretty printing

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,11 @@
+python
+print("---- Loading Rust pretty-printers ----")
+
+import os
+sys.path.insert(0, os.getcwd() + "/etc/")
+
+import gdb_rust_pretty_printing
+gdb_rust_pretty_printing.register_printers(gdb)
+
+end
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 target
+
+# Script artifacts
+etc/__pycache__/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "type": "gdb",
+            "request": "launch",
+            "target": "./target/debug/zi",
+            "arguments": "--help",
+            "cwd": "${workspaceRoot}"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,31 @@ Common options:
     --exclude=<glob>   Ignore objects in the archives whose name
                        is like this glob pattern.
 ```
+
+## How to set up your development environment
+1. Make sure you are on nightly. One of the crates we use in this project uses a feature flag and will not compile on stable. The easiest way to do this is `rustup install nightly`.
+2. `rustup default nightly` and then `cargo build`
+3. You should be able to run `targets/debug/zi` now.
+4. (**Bonus**) You can set up VS Code with the Rust Language Server and GDB for a full IDE experience. See the following section for detailed instructions.
+
+### Rust Language Server for an IDE experience using Visual Studio Code
+  - You will need to be on nightly to install the Rust Language Server (RLS). Specific directions for this can be found [here](https://github.com/rust-lang-nursery/rls).
+  - You will need to install [this VS Code extension](https://github.com/editor-rs/vscode-rust).
+  - I had to add the following configuration in my user settings to help the VS Code extension find my RLS installation. This worked on my Fedora 26 machine, but your mileage will vary depending on how your `rustup` and operating system are set up.
+    ```
+    "rust.rls": {
+            "executable": "rustup",
+            "args": ["run", "nightly", "rls"]
+        }
+    ```
+   - You should see a status indicator in the bottom left-hand corner of VS Code with something along the lines of `RLS: Analysis finished`.
+
+### Setting up GDB debugging with the VS Code extension
+  - Since OS X ditched gdb for LLDB, you will need to install GDB if you want to use this VS Code extension on a Mac. ([Source](https://medium.com/@royalstream/rust-development-using-vs-code-on-os-x-debugging-included-bc10c9863777))
+  - Install [this plugin](https://github.com/WebFreak001/code-debug). (The gdb target settings in `launch.json` are already defined for you inside the `.vscode` folder, so you should see a green play arrow with the target name **Debug** already ready for you when you open the Debugging pane in VS Code.)
+  - There are Rust GDB pretty-printing scripts that are already loaded in the `etc` folder of this repository, straight from the Rust distribution, since we cannot call `rust-gdb` from our VS Code extension (and Windows installations will automatically omit these files, so we will have to end up manually copying them over anyway to debug on Windows). These pretty-printers will be loaded by the `.gdbinit` in the root directory of this repository.
+  - On my Fedora machine, I had a problem with this project's `.gdbinit` not loading properly until it was whitelisted in the `.gdbinit` in my home directory. In that home directory `.gdbinit`, I had to add this following bit to whitelist this project's `.gdbinit`:
+    ```
+    add-auto-load-safe-path <PATH_TO_THIS_REPO_FOLDER>
+    ```
+    (You can also whitelist all `.gdbinit` on your system by adding the bit `add-auto-load-safe-path /`.)

--- a/etc/debugger_pretty_printers_common.py
+++ b/etc/debugger_pretty_printers_common.py
@@ -1,0 +1,347 @@
+# Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""
+This module provides an abstraction layer over common Rust pretty printing
+functionality needed by both GDB and LLDB.
+"""
+
+import re
+
+# Type codes that indicate the kind of type as it appears in DWARF debug
+# information. This code alone is not sufficient to determine the Rust type.
+# For example structs, tuples, fat pointers, or enum variants will all have
+# DWARF_TYPE_CODE_STRUCT.
+DWARF_TYPE_CODE_STRUCT = 1
+DWARF_TYPE_CODE_UNION  = 2
+DWARF_TYPE_CODE_PTR    = 3
+DWARF_TYPE_CODE_ARRAY  = 4
+DWARF_TYPE_CODE_ENUM   = 5
+
+# These constants specify the most specific kind of type that could be
+# determined for a given value.
+TYPE_KIND_UNKNOWN           = -1
+TYPE_KIND_EMPTY             = 0
+TYPE_KIND_SLICE             = 1
+TYPE_KIND_REGULAR_STRUCT    = 2
+TYPE_KIND_TUPLE             = 3
+TYPE_KIND_TUPLE_STRUCT      = 4
+TYPE_KIND_CSTYLE_VARIANT    = 5
+TYPE_KIND_TUPLE_VARIANT     = 6
+TYPE_KIND_STRUCT_VARIANT    = 7
+TYPE_KIND_STR_SLICE         = 8
+TYPE_KIND_STD_VEC           = 9
+TYPE_KIND_STD_STRING        = 10
+TYPE_KIND_REGULAR_ENUM      = 11
+TYPE_KIND_COMPRESSED_ENUM   = 12
+TYPE_KIND_SINGLETON_ENUM    = 13
+TYPE_KIND_CSTYLE_ENUM       = 14
+TYPE_KIND_PTR               = 15
+TYPE_KIND_FIXED_SIZE_VEC    = 16
+TYPE_KIND_REGULAR_UNION     = 17
+
+ENCODED_ENUM_PREFIX = "RUST$ENCODED$ENUM$"
+ENUM_DISR_FIELD_NAME = "RUST$ENUM$DISR"
+
+# Slice related constants
+SLICE_FIELD_NAME_DATA_PTR = "data_ptr"
+SLICE_FIELD_NAME_LENGTH = "length"
+SLICE_FIELD_NAMES = [SLICE_FIELD_NAME_DATA_PTR, SLICE_FIELD_NAME_LENGTH]
+
+# std::Vec<> related constants
+STD_VEC_FIELD_NAME_LENGTH = "len"
+STD_VEC_FIELD_NAME_BUF = "buf"
+STD_VEC_FIELD_NAMES = [STD_VEC_FIELD_NAME_BUF,
+                       STD_VEC_FIELD_NAME_LENGTH]
+
+# std::String related constants
+STD_STRING_FIELD_NAMES = ["vec"]
+
+
+class Type(object):
+    """
+    This class provides a common interface for type-oriented operations.
+    Sub-classes are supposed to wrap a debugger-specific type-object and
+    provide implementations for the abstract methods in this class.
+    """
+
+    def __init__(self):
+        self.__type_kind = None
+
+    def get_unqualified_type_name(self):
+        """
+        Implementations of this method should return the unqualified name of the
+        type-object they are wrapping. Some examples:
+
+        'int' -> 'int'
+        'std::vec::Vec<std::string::String>' -> 'Vec<std::string::String>'
+        '&std::option::Option<std::string::String>' -> '&std::option::Option<std::string::String>'
+
+        As you can see, type arguments stay fully qualified.
+        """
+        raise NotImplementedError("Override this method")
+
+    def get_dwarf_type_kind(self):
+        """
+        Implementations of this method should return the correct
+        DWARF_TYPE_CODE_* value for the wrapped type-object.
+        """
+        raise NotImplementedError("Override this method")
+
+    def get_fields(self):
+        """
+        Implementations of this method should return a list of field-objects of
+        this type. For Rust-enums (i.e. with DWARF_TYPE_CODE_UNION) these field-
+        objects represent the variants of the enum. Field-objects must have a
+        `name` attribute that gives their name as specified in DWARF.
+        """
+        assert ((self.get_dwarf_type_kind() == DWARF_TYPE_CODE_STRUCT) or
+                (self.get_dwarf_type_kind() == DWARF_TYPE_CODE_UNION))
+        raise NotImplementedError("Override this method")
+
+    def get_wrapped_value(self):
+        """
+        Returns the debugger-specific type-object wrapped by this object. This
+        is sometimes needed for doing things like pointer-arithmetic in GDB.
+        """
+        raise NotImplementedError("Override this method")
+
+    def get_type_kind(self):
+        """This method returns the TYPE_KIND_* value for this type-object."""
+        if self.__type_kind is None:
+            dwarf_type_code = self.get_dwarf_type_kind()
+
+            if dwarf_type_code == DWARF_TYPE_CODE_STRUCT:
+                self.__type_kind = self.__classify_struct()
+            elif dwarf_type_code == DWARF_TYPE_CODE_UNION:
+                self.__type_kind = self.__classify_union()
+            elif dwarf_type_code == DWARF_TYPE_CODE_PTR:
+                self.__type_kind = TYPE_KIND_PTR
+            elif dwarf_type_code == DWARF_TYPE_CODE_ARRAY:
+                self.__type_kind = TYPE_KIND_FIXED_SIZE_VEC
+            else:
+                self.__type_kind = TYPE_KIND_UNKNOWN
+        return self.__type_kind
+
+    def __classify_struct(self):
+        assert self.get_dwarf_type_kind() == DWARF_TYPE_CODE_STRUCT
+
+        unqualified_type_name = self.get_unqualified_type_name()
+
+        # STR SLICE
+        if unqualified_type_name == "&str":
+            return TYPE_KIND_STR_SLICE
+
+        # REGULAR SLICE
+        if (unqualified_type_name.startswith(("&[", "&mut [")) and
+            unqualified_type_name.endswith("]") and
+            self.__conforms_to_field_layout(SLICE_FIELD_NAMES)):
+            return TYPE_KIND_SLICE
+
+        fields = self.get_fields()
+        field_count = len(fields)
+
+        # EMPTY STRUCT
+        if field_count == 0:
+            return TYPE_KIND_EMPTY
+
+        # STD VEC
+        if (unqualified_type_name.startswith("Vec<") and
+            self.__conforms_to_field_layout(STD_VEC_FIELD_NAMES)):
+            return TYPE_KIND_STD_VEC
+
+        # STD STRING
+        if (unqualified_type_name.startswith("String") and
+            self.__conforms_to_field_layout(STD_STRING_FIELD_NAMES)):
+            return TYPE_KIND_STD_STRING
+
+        # ENUM VARIANTS
+        if fields[0].name == ENUM_DISR_FIELD_NAME:
+            if field_count == 1:
+                return TYPE_KIND_CSTYLE_VARIANT
+            elif self.__all_fields_conform_to_tuple_field_naming(1):
+                return TYPE_KIND_TUPLE_VARIANT
+            else:
+                return TYPE_KIND_STRUCT_VARIANT
+
+        # TUPLE
+        if self.__all_fields_conform_to_tuple_field_naming(0):
+            if unqualified_type_name.startswith("("):
+                return TYPE_KIND_TUPLE
+            else:
+                return TYPE_KIND_TUPLE_STRUCT
+
+        # REGULAR STRUCT
+        return TYPE_KIND_REGULAR_STRUCT
+
+
+    def __classify_union(self):
+        assert self.get_dwarf_type_kind() == DWARF_TYPE_CODE_UNION
+
+        union_members = self.get_fields()
+        union_member_count = len(union_members)
+        if union_member_count == 0:
+            return TYPE_KIND_EMPTY
+
+        first_variant_name = union_members[0].name
+        if first_variant_name is None:
+            if union_member_count == 1:
+                return TYPE_KIND_SINGLETON_ENUM
+            else:
+                return TYPE_KIND_REGULAR_ENUM
+        elif first_variant_name.startswith(ENCODED_ENUM_PREFIX):
+            assert union_member_count == 1
+            return TYPE_KIND_COMPRESSED_ENUM
+        else:
+            return TYPE_KIND_REGULAR_UNION
+
+
+    def __conforms_to_field_layout(self, expected_fields):
+        actual_fields = self.get_fields()
+        actual_field_count = len(actual_fields)
+
+        if actual_field_count != len(expected_fields):
+            return False
+
+        for i in range(0, actual_field_count):
+            if actual_fields[i].name != expected_fields[i]:
+                return False
+
+        return True
+
+    def __all_fields_conform_to_tuple_field_naming(self, start_index):
+        fields = self.get_fields()
+        field_count = len(fields)
+
+        for i in range(start_index, field_count):
+            field_name = fields[i].name
+            if (field_name is None) or (re.match(r"__\d+$", field_name) is None):
+                return False
+        return True
+
+
+class Value(object):
+    """
+    This class provides a common interface for value-oriented operations.
+    Sub-classes are supposed to wrap a debugger-specific value-object and
+    provide implementations for the abstract methods in this class.
+    """
+    def __init__(self, ty):
+        self.type = ty
+
+    def get_child_at_index(self, index):
+        """Returns the value of the field, array element or variant at the given index"""
+        raise NotImplementedError("Override this method")
+
+    def as_integer(self):
+        """
+        Try to convert the wrapped value into a Python integer. This should
+        always succeed for values that are pointers or actual integers.
+        """
+        raise NotImplementedError("Override this method")
+
+    def get_wrapped_value(self):
+        """
+        Returns the debugger-specific value-object wrapped by this object. This
+        is sometimes needed for doing things like pointer-arithmetic in GDB.
+        """
+        raise NotImplementedError("Override this method")
+
+
+class EncodedEnumInfo(object):
+    """
+    This class provides facilities for handling enum values with compressed
+    encoding where a non-null field in one variant doubles as the discriminant.
+    """
+
+    def __init__(self, enum_val):
+        assert enum_val.type.get_type_kind() == TYPE_KIND_COMPRESSED_ENUM
+        variant_name = enum_val.type.get_fields()[0].name
+        last_separator_index = variant_name.rfind("$")
+        start_index = len(ENCODED_ENUM_PREFIX)
+        indices_substring = variant_name[start_index:last_separator_index].split("$")
+        self.__enum_val = enum_val
+        self.__disr_field_indices = [int(index) for index in indices_substring]
+        self.__null_variant_name = variant_name[last_separator_index + 1:]
+
+    def is_null_variant(self):
+        ty = self.__enum_val.type
+        sole_variant_val = self.__enum_val.get_child_at_index(0)
+        discriminant_val = sole_variant_val
+        for disr_field_index in self.__disr_field_indices:
+            discriminant_val = discriminant_val.get_child_at_index(disr_field_index)
+
+        # If the discriminant field is a fat pointer we have to consider the
+        # first word as the true discriminant
+        if discriminant_val.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_STRUCT:
+            discriminant_val = discriminant_val.get_child_at_index(0)
+
+        return discriminant_val.as_integer() == 0
+
+    def get_non_null_variant_val(self):
+        return self.__enum_val.get_child_at_index(0)
+
+    def get_null_variant_name(self):
+        return self.__null_variant_name
+
+
+def get_discriminant_value_as_integer(enum_val):
+    assert enum_val.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_UNION
+    # we can take any variant here because the discriminant has to be the same
+    # for all of them.
+    variant_val = enum_val.get_child_at_index(0)
+    disr_val = variant_val.get_child_at_index(0)
+    return disr_val.as_integer()
+
+
+def extract_length_ptr_and_cap_from_std_vec(vec_val):
+    assert vec_val.type.get_type_kind() == TYPE_KIND_STD_VEC
+    length_field_index = STD_VEC_FIELD_NAMES.index(STD_VEC_FIELD_NAME_LENGTH)
+    buf_field_index = STD_VEC_FIELD_NAMES.index(STD_VEC_FIELD_NAME_BUF)
+
+    length = vec_val.get_child_at_index(length_field_index).as_integer()
+    buf = vec_val.get_child_at_index(buf_field_index)
+
+    vec_ptr_val = buf.get_child_at_index(0)
+    capacity = buf.get_child_at_index(1).as_integer()
+    unique_ptr_val = vec_ptr_val.get_child_at_index(0)
+    data_ptr = unique_ptr_val.get_child_at_index(0)
+    assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
+    return (length, data_ptr, capacity)
+
+def extract_length_and_ptr_from_slice(slice_val):
+    assert (slice_val.type.get_type_kind() == TYPE_KIND_SLICE or
+            slice_val.type.get_type_kind() == TYPE_KIND_STR_SLICE)
+
+    length_field_index = SLICE_FIELD_NAMES.index(SLICE_FIELD_NAME_LENGTH)
+    ptr_field_index = SLICE_FIELD_NAMES.index(SLICE_FIELD_NAME_DATA_PTR)
+
+    length = slice_val.get_child_at_index(length_field_index).as_integer()
+    data_ptr = slice_val.get_child_at_index(ptr_field_index)
+
+    assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
+    return (length, data_ptr)
+
+UNQUALIFIED_TYPE_MARKERS = frozenset(["(", "[", "&", "*"])
+
+def extract_type_name(qualified_type_name):
+    """Extracts the type name from a fully qualified path"""
+    if qualified_type_name[0] in UNQUALIFIED_TYPE_MARKERS:
+        return qualified_type_name
+
+    end_of_search = qualified_type_name.find("<")
+    if end_of_search < 0:
+        end_of_search = len(qualified_type_name)
+
+    index = qualified_type_name.rfind("::", 0, end_of_search)
+    if index < 0:
+        return qualified_type_name
+    else:
+        return qualified_type_name[index + 2:]

--- a/etc/gdb_load_rust_pretty_printers.py
+++ b/etc/gdb_load_rust_pretty_printers.py
@@ -1,0 +1,12 @@
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import gdb_rust_pretty_printing
+gdb_rust_pretty_printing.register_printers(gdb.current_objfile())

--- a/etc/gdb_rust_pretty_printing.py
+++ b/etc/gdb_rust_pretty_printing.py
@@ -1,0 +1,294 @@
+# Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import gdb
+import re
+import sys
+import debugger_pretty_printers_common as rustpp
+
+# We want a version of `range` which doesn't allocate an intermediate list,
+# specifically it should use a lazy iterator. In Python 2 this was `xrange`, but
+# if we're running with Python 3 then we need to use `range` instead.
+if sys.version_info[0] >= 3:
+    xrange = range
+
+#===============================================================================
+# GDB Pretty Printing Module for Rust
+#===============================================================================
+
+class GdbType(rustpp.Type):
+
+    def __init__(self, ty):
+        super(GdbType, self).__init__()
+        self.ty = ty
+        self.fields = None
+
+    def get_unqualified_type_name(self):
+        tag = self.ty.tag
+
+        if tag is None:
+            return tag
+
+        return rustpp.extract_type_name(tag).replace("&'static ", "&")
+
+    def get_dwarf_type_kind(self):
+        if self.ty.code == gdb.TYPE_CODE_STRUCT:
+            return rustpp.DWARF_TYPE_CODE_STRUCT
+
+        if self.ty.code == gdb.TYPE_CODE_UNION:
+            return rustpp.DWARF_TYPE_CODE_UNION
+
+        if self.ty.code == gdb.TYPE_CODE_PTR:
+            return rustpp.DWARF_TYPE_CODE_PTR
+
+        if self.ty.code == gdb.TYPE_CODE_ENUM:
+            return rustpp.DWARF_TYPE_CODE_ENUM
+
+    def get_fields(self):
+        assert ((self.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_STRUCT) or
+                (self.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_UNION))
+        if self.fields is None:
+            self.fields = list(self.ty.fields())
+        return self.fields
+
+    def get_wrapped_value(self):
+        return self.ty
+
+
+class GdbValue(rustpp.Value):
+    def __init__(self, gdb_val):
+        super(GdbValue, self).__init__(GdbType(gdb_val.type))
+        self.gdb_val = gdb_val
+        self.children = {}
+
+    def get_child_at_index(self, index):
+        child = self.children.get(index)
+        if child is None:
+            gdb_field = get_field_at_index(self.gdb_val, index)
+            child = GdbValue(self.gdb_val[gdb_field])
+            self.children[index] = child
+        return child
+
+    def as_integer(self):
+        if self.gdb_val.type.code == gdb.TYPE_CODE_PTR:
+            return int(str(self.gdb_val), 0)
+        return int(self.gdb_val)
+
+    def get_wrapped_value(self):
+        return self.gdb_val
+
+
+def register_printers(objfile):
+    """Registers Rust pretty printers for the given objfile"""
+    objfile.pretty_printers.append(rust_pretty_printer_lookup_function)
+
+
+def rust_pretty_printer_lookup_function(gdb_val):
+    """
+    Returns the correct Rust pretty printer for the given value
+    if there is one
+    """
+
+    val = GdbValue(gdb_val)
+    type_kind = val.type.get_type_kind()
+
+    if (type_kind == rustpp.TYPE_KIND_REGULAR_STRUCT or
+        type_kind == rustpp.TYPE_KIND_EMPTY):
+        return RustStructPrinter(val,
+                                 omit_first_field = False,
+                                 omit_type_name = False,
+                                 is_tuple_like = False)
+
+    if type_kind == rustpp.TYPE_KIND_STRUCT_VARIANT:
+        return RustStructPrinter(val,
+                                 omit_first_field = True,
+                                 omit_type_name = False,
+                                 is_tuple_like = False)
+
+    if type_kind == rustpp.TYPE_KIND_SLICE:
+        return RustSlicePrinter(val)
+
+    if type_kind == rustpp.TYPE_KIND_STR_SLICE:
+        return RustStringSlicePrinter(val)
+
+    if type_kind == rustpp.TYPE_KIND_STD_VEC:
+        return RustStdVecPrinter(val)
+
+    if type_kind == rustpp.TYPE_KIND_STD_STRING:
+        return RustStdStringPrinter(val)
+
+    if type_kind == rustpp.TYPE_KIND_TUPLE:
+        return RustStructPrinter(val,
+                                 omit_first_field = False,
+                                 omit_type_name = True,
+                                 is_tuple_like = True)
+
+    if type_kind == rustpp.TYPE_KIND_TUPLE_STRUCT:
+        return RustStructPrinter(val,
+                                 omit_first_field = False,
+                                 omit_type_name = False,
+                                 is_tuple_like = True)
+
+    if type_kind == rustpp.TYPE_KIND_CSTYLE_VARIANT:
+        return RustCStyleVariantPrinter(val.get_child_at_index(0))
+
+    if type_kind == rustpp.TYPE_KIND_TUPLE_VARIANT:
+        return RustStructPrinter(val,
+                                 omit_first_field = True,
+                                 omit_type_name = False,
+                                 is_tuple_like = True)
+
+    if type_kind == rustpp.TYPE_KIND_SINGLETON_ENUM:
+        variant = get_field_at_index(gdb_val, 0)
+        return rust_pretty_printer_lookup_function(gdb_val[variant])
+
+    if type_kind == rustpp.TYPE_KIND_REGULAR_ENUM:
+        # This is a regular enum, extract the discriminant
+        discriminant_val = rustpp.get_discriminant_value_as_integer(val)
+        variant = get_field_at_index(gdb_val, discriminant_val)
+        return rust_pretty_printer_lookup_function(gdb_val[variant])
+
+    if type_kind == rustpp.TYPE_KIND_COMPRESSED_ENUM:
+        encoded_enum_info = rustpp.EncodedEnumInfo(val)
+        if encoded_enum_info.is_null_variant():
+            return IdentityPrinter(encoded_enum_info.get_null_variant_name())
+
+        non_null_val = encoded_enum_info.get_non_null_variant_val()
+        return rust_pretty_printer_lookup_function(non_null_val.get_wrapped_value())
+
+    # No pretty printer has been found
+    return None
+
+
+#=------------------------------------------------------------------------------
+# Pretty Printer Classes
+#=------------------------------------------------------------------------------
+class RustStructPrinter(object):
+    def __init__(self, val, omit_first_field, omit_type_name, is_tuple_like):
+        self.__val = val
+        self.__omit_first_field = omit_first_field
+        self.__omit_type_name = omit_type_name
+        self.__is_tuple_like = is_tuple_like
+
+    def to_string(self):
+        if self.__omit_type_name:
+            return None
+        return self.__val.type.get_unqualified_type_name()
+
+    def children(self):
+        cs = []
+        wrapped_value = self.__val.get_wrapped_value()
+
+        for field in self.__val.type.get_fields():
+            field_value = wrapped_value[field.name]
+            if self.__is_tuple_like:
+                cs.append(("", field_value))
+            else:
+                cs.append((field.name, field_value))
+
+        if self.__omit_first_field:
+            cs = cs[1:]
+
+        return cs
+
+    def display_hint(self):
+        if self.__is_tuple_like:
+            return "array"
+        else:
+            return ""
+
+
+class RustSlicePrinter(object):
+    def __init__(self, val):
+        self.__val = val
+
+    @staticmethod
+    def display_hint():
+        return "array"
+
+    def to_string(self):
+        (length, data_ptr) = rustpp.extract_length_and_ptr_from_slice(self.__val)
+        return (self.__val.type.get_unqualified_type_name() +
+                ("(len: %i)" % length))
+
+    def children(self):
+        (length, data_ptr) = rustpp.extract_length_and_ptr_from_slice(self.__val)
+        assert data_ptr.type.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_PTR
+        raw_ptr = data_ptr.get_wrapped_value()
+
+        for index in xrange(0, length):
+            yield (str(index), (raw_ptr + index).dereference())
+
+
+class RustStringSlicePrinter(object):
+    def __init__(self, val):
+        self.__val = val
+
+    def to_string(self):
+        (length, data_ptr) = rustpp.extract_length_and_ptr_from_slice(self.__val)
+        raw_ptr = data_ptr.get_wrapped_value()
+        return '"%s"' % raw_ptr.string(encoding="utf-8", length=length)
+
+
+class RustStdVecPrinter(object):
+    def __init__(self, val):
+        self.__val = val
+
+    @staticmethod
+    def display_hint():
+        return "array"
+
+    def to_string(self):
+        (length, data_ptr, cap) = rustpp.extract_length_ptr_and_cap_from_std_vec(self.__val)
+        return (self.__val.type.get_unqualified_type_name() +
+                ("(len: %i, cap: %i)" % (length, cap)))
+
+    def children(self):
+        (length, data_ptr, cap) = rustpp.extract_length_ptr_and_cap_from_std_vec(self.__val)
+        gdb_ptr = data_ptr.get_wrapped_value()
+        for index in xrange(0, length):
+            yield (str(index), (gdb_ptr + index).dereference())
+
+
+class RustStdStringPrinter(object):
+    def __init__(self, val):
+        self.__val = val
+
+    def to_string(self):
+        vec = self.__val.get_child_at_index(0)
+        (length, data_ptr, cap) = rustpp.extract_length_ptr_and_cap_from_std_vec(vec)
+        return '"%s"' % data_ptr.get_wrapped_value().string(encoding="utf-8",
+                                                            length=length)
+
+
+class RustCStyleVariantPrinter(object):
+    def __init__(self, val):
+        assert val.type.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_ENUM
+        self.__val = val
+
+    def to_string(self):
+        return str(self.__val.get_wrapped_value())
+
+
+class IdentityPrinter(object):
+    def __init__(self, string):
+        self.string = string
+
+    def to_string(self):
+        return self.string
+
+
+def get_field_at_index(gdb_val, index):
+    i = 0
+    for field in gdb_val.type.fields():
+        if i == index:
+            return field
+        i += 1
+    return None


### PR DESCRIPTION
Added
 - Updated README instructions for installing VS Code and extensions
 - A directory for VS Code configuration files
 - `launch.json` configuration for VS Code debugging extension targets
 - pretty-printing scripts from the Rust distribution
 - `.gdbinit` to load Rust-GDB pretty-printers plus instructions on how to enable it