### PR TITLE
Fixing the project to show up as a Rust project on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+###############################################################################
+# linguist behavior
+# 
+# Do not count the VS Code and GDB python setups in the language count
+###############################################################################
+etc/* linguist-vendored


### PR DESCRIPTION
Apparently, Github will count the Python files uploaded as a part of VS Code/GDB settings as project code and tell us that the majority of this project is written in Python. That is unacceptable, so we will fix that behavior. :)